### PR TITLE
Troubleshooting an erroring `(explore parallel-step ...)`

### DIFF
--- a/examples.rkt
+++ b/examples.rkt
@@ -13,8 +13,34 @@
   (syntax-rules ()
     ((_ e ...) (begin (example e) ...))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Examples
+(require "common.rkt")
+(require "mk-fo.rkt")
+(require "microk-fo.rkt")
+(require "tools.rkt")
+
+(include "mk-syntax.rkt")
+
+(define-relation (bit-xoro x y z)
+  (conde
+   ((== x 0) (== y 0) (== z 0))
+   ((== x 0) (== y 1) (== z 1))
+   ((== x 1) (== y 0) (== z 1))
+   ((== x 1) (== y 1) (== z 0))))
+
+(query (q)
+       (fresh (x y z)
+              (bit-xoro x y z)
+              (== q `(,x ,y ,z))))
+
+(explore step (query (q) (reverseo q '(3 2 1))))
+
+(explore
+ step
+ (query (q)
+        (fresh (q x y z)
+               (bit-xoro x y z)
+               (== q `(,x ,y ,z)))))
+
 (define-relation (appendo ab c abc)
   (conde
     ((== '() ab) (== c abc))
@@ -23,12 +49,28 @@
        (== `(,a . ,bc) abc)
        (appendo b c bc)))))
 
+
+(explore step (query (q) (appendo )))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Examples
+(define-relation (appendo ab c abc)
+  (conde
+   ((== '() ab) (== c abc))
+   ((fresh (a b bc)
+           (== `(,a . ,b) ab)
+           (== `(,a . ,bc) abc)
+           (appendo b c bc)))))
+
+(explore step (query (q) (appendo q '(2) '(1 2))))
+
 (examples
-  (run* (q) (appendo '(1 2 3) '(4 5) q))
-  (run* (p q) (appendo p q '(1 2 3 4 5)))
-  ;; We can change our search strategy by choosing a different way to step.
-  ;; `step` gives us a typical interleaving search.
-  (run*/step step (p q) (appendo p q '(1 2 3 4 5))))
+ (run* (q) (appendo '(1 2 3) '(4 5) q))
+ (run* (p q) (appendo p q '(1 2 3 4 5)))
+ ;; We can change our search strategy by choosing a different way to step.
+ ;; `step` gives us a typical interleaving search.
+ (run*/step step (p q) (appendo p q '(1 2 3 4 5))))
 
 
 (define-relation (reverseo ys sy)
@@ -52,7 +94,7 @@
 (displayln
 "We can explore the backwards reverseo query to observe its bad behavior.")
 (displayln "Stop exploring by triggering EOF (probably Ctrl-D).")
-(explore step (query (q) (reverseo q '(3 2 1))))
+(explore step (query (q) (reverseo q '(2 1))))
 
 ;; A miniscule relational interpreter.
 (define-relation (evalo expr env value)

--- a/examples.rkt
+++ b/examples.rkt
@@ -37,7 +37,42 @@
            (== `(,a . ,bc) abc)
            (appendo b c bc)))))
 
-(explore step (query (q) (appendo q '(2) '(1 2))))
+;;;; Works fine
+;; (explore step (query (q) (appendo q '(2) '(1 2))))
+
+(explore parallel-step (query  (a b) (appendo a b '(1 2 3 4))))
+;;;; Errors with the following:
+;;
+;; Using step procedure: parallel-step
+;; Exploring query:
+;; (query (a b) (appendo a b (quote (1 2 3 4))))
+
+;; ================================================================================
+;; Current Depth: 0
+;; Number of Choices: 1
+
+;; | Choice 1:
+;; |  a = #s(var a 3)
+;; |  b = #s(var b 4)
+;; |  Constraints:
+;; |  * (appendo #s(var a 3) #s(var b 4) (1 2 3 4))
+
+;; [h]elp, [u]ndo, or choice number>
+;; 1
+
+;; ================================================================================
+;; Previous Choice:
+;; |  a = #s(var a 3)
+;; |  b = #s(var b 4)
+;; |  Constraints:
+;; |  * (appendo #s(var a 3) #s(var b 4) (1 2 3 4))
+
+;; Current Depth: 1
+;; Number of Choices: 2
+
+;; | Choice 1:
+;; match: no matching clause for #s(bind #s(state ((#s(var #f 0) #s(var a 3) #s(var b 4))) () () ()) #s(conj #s(== () #s(var a 3)) #s(== #s(var b 4) (1 2 3 4))))
+
 
 (examples
  (run* (q) (appendo '(1 2 3) '(4 5) q))

--- a/examples.rkt
+++ b/examples.rkt
@@ -27,32 +27,6 @@
    ((== x 1) (== y 0) (== z 1))
    ((== x 1) (== y 1) (== z 0))))
 
-(query (q)
-       (fresh (x y z)
-              (bit-xoro x y z)
-              (== q `(,x ,y ,z))))
-
-(explore step (query (q) (reverseo q '(3 2 1))))
-
-(explore
- step
- (query (q)
-        (fresh (q x y z)
-               (bit-xoro x y z)
-               (== q `(,x ,y ,z)))))
-
-(define-relation (appendo ab c abc)
-  (conde
-    ((== '() ab) (== c abc))
-    ((fresh (a b bc)
-       (== `(,a . ,b) ab)
-       (== `(,a . ,bc) abc)
-       (appendo b c bc)))))
-
-
-(explore step (query (q) (appendo )))
-
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Examples
 (define-relation (appendo ab c abc)

--- a/math.rkt
+++ b/math.rkt
@@ -2,7 +2,10 @@
 (require "tools.rkt")
 (provide
  poso
+ <lo
+ <o
  pluso)
+
 (define-relation (appendo xs ys xsys)
   (conde ((== xs '()) (== ys xsys))
          ((fresh (x zs zsys)

--- a/math.rkt
+++ b/math.rkt
@@ -1,0 +1,369 @@
+#lang racket
+(require "tools.rkt")
+(provide
+ poso
+ pluso)
+(define-relation (appendo xs ys xsys)
+  (conde ((== xs '()) (== ys xsys))
+         ((fresh (x zs zsys)
+            (== `(,x . ,zs)   xs)
+            (== `(,x . ,zsys) xsys)
+            (appendo zs ys zsys)))))
+
+(define-relation (nevero x) (nevero x))
+(define-relation (alwayso x)
+  (conde ((== #t x))
+         ((alwayso x))))
+(define-relation (sometimeso x)
+  (conde ((nevero x))
+         ((alwayso x))))
+
+(define-relation (color c)
+  (conde ((== c 'red))
+         ((== c 'green))
+         ((== c 'blue))
+         ((== c 'cyan))
+         ((== c 'magenta))
+         ((== c 'yellow))
+         ((== c 'black))
+         ((== c 'white))))
+(define-relation (shape s)
+  (conde ((== s 'circle))
+         ((== s 'triangle))
+         ((== s 'rectangle))
+         ((== s 'pentagon))
+         ((== s 'hexagon))))
+(define-relation (shape-or-color sc)
+  (conde ((shape sc)) ((color sc))))
+
+;; This is an interpreter for a simple Lisp.  Variables in this language are
+;; represented namelessly, using De Bruijn indices.
+;; Because it is implemented as a relation, we can run this interpreter with
+;; unknowns in any argument position.  If we place unknowns in the `expr`
+;; position, we can synthesize programs.
+(define-relation (eval-expo expr env value)
+  (conde ;; NOTE: this clause order is optimized for quine generation.
+    ((fresh (body)
+       (== `(lambda ,body) expr)      ;; expr is a procedure definition
+       (== `(closure ,body ,env) value)))
+    ;; If this is before lambda, quoted closures become likely.
+    ((== `(quote ,value) expr))       ;; expr is a literal constant
+    ((fresh (a*)
+       (== `(list . ,a*) expr)        ;; expr is a list operation
+       (eval-listo a* env value)))
+    ((fresh (a d va vd)
+       (== `(cons ,a ,d) expr)        ;; expr is a cons operation
+       (== `(,va . ,vd) value)
+       (eval-expo a env va)
+       (eval-expo d env vd)))
+    ((fresh (index)
+       (== `(var ,index) expr)        ;; expr is a variable
+       (lookupo index env value)))
+    ;((fresh (c va vd)
+       ;(== `(car ,c) expr)            ;; expr is a car operation
+       ;(== va value)
+       ;(eval-expo c env `(,va . ,vd))))
+    ;((fresh (c va vd)
+       ;(== `(cdr ,c) expr)            ;; expr is a cdr operation
+       ;(== vd value)
+       ;(eval-expo c env `(,va . ,vd))))
+    ((fresh (rator rand arg env^ body)
+       (== `(app ,rator ,rand) expr)  ;; expr is a procedure application
+       (eval-expo rator env `(closure ,body ,env^))
+       (eval-expo rand env arg)
+       (eval-expo body `(,arg . ,env^) value)))))
+
+;; Lookup the value a variable is bound to.
+;; Variables are represented namelessly using relative De Bruijn indices.
+;; These indices are encoded as peano numerals: (), (s), (s s), etc.
+(define-relation (lookupo index env value)
+  (fresh (arg e*)
+    (== `(,arg . ,e*) env)
+    (conde
+      ((== '() index) (== arg value))
+      ((fresh (i* a d)
+         (== `(s . ,i*) index)
+         (== `(,a . ,d) e*)
+         (lookupo i* e* value))))))
+
+;; This helper evaluates arguments to a list construction.
+(define-relation (eval-listo e* env value)
+  (conde
+    ((== '() e*) (== '() value))
+    ((fresh (ea ed va vd)
+       (== `(,ea . ,ed) e*)
+       (== `(,va . ,vd) value)
+       (eval-expo ea env va)
+       (eval-listo ed env vd)))))
+
+(define (evalo expr value) (eval-expo expr '() value))
+;; Relational arithmetic
+(define (build-num n)
+  (cond
+    ((odd? n)
+     (cons 1
+           (build-num (quotient (- n 1) 2))))
+    ((and (not (zero? n)) (even? n))
+     (cons 0
+           (build-num (quotient n 2))))
+    ((zero? n) '())))
+
+(define-relation (zeroo n)
+  (== '() n))
+
+(define-relation (poso n)
+  (fresh (a d)
+    (== `(,a . ,d) n)))
+
+(define-relation (>1o n)
+  (fresh (a ad dd)
+    (== `(,a ,ad . ,dd) n)))
+
+(define-relation (full-addero b x y r c)
+  (conde
+    ((== 0 b) (== 0 x) (== 0 y) (== 0 r) (== 0 c))
+    ((== 1 b) (== 0 x) (== 0 y) (== 1 r) (== 0 c))
+    ((== 0 b) (== 1 x) (== 0 y) (== 1 r) (== 0 c))
+    ((== 1 b) (== 1 x) (== 0 y) (== 0 r) (== 1 c))
+    ((== 0 b) (== 0 x) (== 1 y) (== 1 r) (== 0 c))
+    ((== 1 b) (== 0 x) (== 1 y) (== 0 r) (== 1 c))
+    ((== 0 b) (== 1 x) (== 1 y) (== 0 r) (== 1 c))
+    ((== 1 b) (== 1 x) (== 1 y) (== 1 r) (== 1 c))))
+
+(define-relation (addero d n m r)
+  (conde
+    ((== 0 d) (== '() m) (== n r))
+    ((== 0 d) (== '() n) (== m r)
+              (poso m))
+    ((== 1 d) (== '() m)
+              (addero 0 n '(1) r))
+    ((== 1 d) (== '() n) (poso m)
+              (addero 0 '(1) m r))
+    ((== '(1) n) (== '(1) m)
+                 (fresh (a c)
+                   (== `(,a ,c) r)
+                   (full-addero d 1 1 a c)))
+    ((== '(1) n) (gen-addero d n m r))
+    ((== '(1) m) (>1o n) (>1o r)
+                 (addero d '(1) n r))
+    ((>1o n) (gen-addero d n m r))))
+
+(define-relation (gen-addero d n m r)
+  (fresh (a b c e x y z)
+    (== `(,a . ,x) n)
+    (== `(,b . ,y) m) (poso y)
+    (== `(,c . ,z) r) (poso z)
+    (full-addero d a b c e)
+    (addero e x y z)))
+
+(define-relation (pluso n m k)
+  (addero 0 n m k))
+
+(define-relation (minuso n m k)
+  (pluso m k n))
+
+(define-relation (*o n m p)
+  (conde
+    ((== '() n) (== '() p))
+    ((poso n) (== '() m) (== '() p))
+    ((== '(1) n) (poso m) (== m p))
+    ((>1o n) (== '(1) m) (== n p))
+    ((fresh (x z)
+       (== `(0 . ,x) n) (poso x)
+       (== `(0 . ,z) p) (poso z)
+       (>1o m)
+       (*o x m z)))
+    ((fresh (x y)
+       (== `(1 . ,x) n) (poso x)
+       (== `(0 . ,y) m) (poso y)
+       (*o m n p)))
+    ((fresh (x y)
+       (== `(1 . ,x) n) (poso x)
+       (== `(1 . ,y) m) (poso y)
+       (odd-*o x n m p)))))
+
+(define-relation (odd-*o x n m p)
+  (fresh (q)
+    (bound-*o q p n m)
+    (*o x m q)
+    (pluso `(0 . ,q) m p)))
+
+(define-relation (bound-*o q p n m)
+  (conde
+    ((== '() q) (poso p))
+    ((fresh (a0 a1 a2 a3 x y z)
+       (== `(,a0 . ,x) q)
+       (== `(,a1 . ,y) p)
+       (conde
+         ((== '() n)
+          (== `(,a2 . ,z) m)
+          (bound-*o x y z '()))
+         ((== `(,a3 . ,z) n)
+          (bound-*o x y z m)))))))
+
+(define-relation (=lo n m)
+  (conde
+    ((== '() n) (== '() m))
+    ((== '(1) n) (== '(1) m))
+    ((fresh (a x b y)
+       (== `(,a . ,x) n) (poso x)
+       (== `(,b . ,y) m) (poso y)
+       (=lo x y)))))
+
+(define-relation (<lo n m)
+  (conde
+    ((== '() n) (poso m))
+    ((== '(1) n) (>1o m))
+    ((fresh (a x b y)
+       (== `(,a . ,x) n) (poso x)
+       (== `(,b . ,y) m) (poso y)
+       (<lo x y)))))
+
+(define-relation (<=lo n m)
+  (conde
+    ((=lo n m))
+    ((<lo n m))))
+
+(define-relation (<o n m)
+  (conde
+    ((<lo n m))
+    ((=lo n m)
+     (fresh (x)
+       (poso x)
+       (pluso n x m)))))
+
+(define-relation (<=o n m)
+  (conde
+    ((== n m))
+    ((<o n m))))
+
+(define-relation (/o n m q r)
+  (conde
+    ((== r n) (== '() q) (<o n m))
+    ((== '(1) q) (=lo n m) (pluso r m n)
+                 (<o r m))
+    ((<lo m n)
+     (<o r m)
+     (poso q)
+     (fresh (nh nl qh ql qlm qlmr rr rh)
+       (splito n r nl nh)
+       (splito q r ql qh)
+       (conde
+         ((== '() nh)
+          (== '() qh)
+          (minuso nl r qlm)
+          (*o ql m qlm))
+         ((poso nh)
+          (*o ql m qlm)
+          (pluso qlm r qlmr)
+          (minuso qlmr nl rr)
+          (splito rr r '() rh)
+          (/o nh m qh rh)))))))
+
+(define-relation (splito n r l h)
+  (conde
+    ((== '() n) (== '() h) (== '() l))
+    ((fresh (b n^)
+       (== `(0 ,b . ,n^) n)
+       (== '() r)
+       (== `(,b . ,n^) h)
+       (== '() l)))
+    ((fresh (n^)
+       (== `(1 . ,n^) n)
+       (== '() r)
+       (== n^ h)
+       (== '(1) l)))
+    ((fresh (b n^ a r^)
+       (== `(0 ,b . ,n^) n)
+       (== `(,a . ,r^) r)
+       (== '() l)
+       (splito `(,b . ,n^) r^ '() h)))
+    ((fresh (n^ a r^)
+       (== `(1 . ,n^) n)
+       (== `(,a . ,r^) r)
+       (== '(1) l)
+       (splito n^ r^ '() h)))
+    ((fresh (b n^ a r^ l^)
+       (== `(,b . ,n^) n)
+       (== `(,a . ,r^) r)
+       (== `(,b . ,l^) l)
+       (poso l^)
+       (splito n^ r^ l^ h)))))
+
+(define-relation (logo n b q r)
+  (conde
+    ((== '(1) n) (poso b) (== '() q) (== '() r))
+    ((== '() q) (<o n b) (pluso r '(1) n))
+    ((== '(1) q) (>1o b) (=lo n b) (pluso r b n))
+    ((== '(1) b) (poso q) (pluso r '(1) n))
+    ((== '() b) (poso q) (== r n))
+    ((== '(0 1) b)
+     (fresh (a ad dd)
+       (poso dd)
+       (== `(,a ,ad . ,dd) n)
+       (exp2 n '() q)
+       (fresh (s)
+         (splito n dd r s))))
+    ((fresh (a ad add ddd)
+       (conde
+         ((== '(1 1) b))
+         ((== `(,a ,ad ,add . ,ddd) b))))
+     (<lo b n)
+     (fresh (bw1 bw nw nw1 ql1 ql s)
+       (exp2 b '() bw1)
+       (pluso bw1 '(1) bw)
+       (<lo q n)
+       (fresh (q1 bwq1)
+         (pluso q '(1) q1)
+         (*o bw q1 bwq1)
+         (<o nw1 bwq1))
+       (exp2 n '() nw1)
+       (pluso nw1 '(1) nw)
+       (/o nw bw ql1 s)
+       (pluso ql '(1) ql1)
+       (<=lo ql q)
+       (fresh (bql qh s qdh qd)
+         (repeated-mul b ql bql)
+         (/o nw bw1 qh s)
+         (pluso ql qdh qh)
+         (pluso ql qd q)
+         (<=o qd qdh)
+         (fresh (bqd bq1 bq)
+           (repeated-mul b qd bqd)
+           (*o bql bqd bq)
+           (*o b bq bq1)
+           (pluso bq r n)
+           (<o n bq1)))))))
+
+(define-relation (exp2 n b q)
+  (conde
+    ((== '(1) n) (== '() q))
+    ((>1o n) (== '(1) q)
+             (fresh (s)
+               (splito n b s '(1))))
+    ((fresh (q1 b2)
+       (== `(0 . ,q1) q)
+       (poso q1)
+       (<lo b n)
+       (appendo b `(1 . ,b) b2)
+       (exp2 n b2 q1)))
+    ((fresh (q1 nh b2 s)
+       (== `(1 . ,q1) q)
+       (poso q1)
+       (poso nh)
+       (splito n b s nh)
+       (appendo b `(1 . ,b) b2)
+       (exp2 nh b2 q1)))))
+
+(define-relation (repeated-mul n q nq)
+  (conde
+    ((poso n) (== '() q) (== '(1) nq))
+    ((== '(1) q) (== n nq))
+    ((>1o q)
+     (fresh (q1 nq1)
+       (pluso q1 '(1) q)
+       (repeated-mul n q1 nq1)
+       (*o nq1 n nq)))))
+
+(define-relation (expo b q n)
+  (logo n b q '()))

--- a/microk-fo.rkt
+++ b/microk-fo.rkt
@@ -16,6 +16,7 @@
   (struct-out bind)
   (struct-out pause)
   step
+  start
   mature
   mature?)
 

--- a/mk-syntax.rkt
+++ b/mk-syntax.rkt
@@ -1,3 +1,6 @@
+#lang racket
+(require "microk-fo.rkt")
+(provide run)
 (define-syntax define-relation
   (syntax-rules ()
     ((_ (name param ...) g ...)
@@ -25,20 +28,24 @@
   (syntax-rules ()
     ((_ (g gs ...) (h hs ...) ...)
      (disj* (conj* g gs ...) (conj* h hs ...) ...))))
+
 ;; Queries
 (define-syntax query
   (syntax-rules ()
     ((_ (x ...) g0 gs ...)
      (let ((goal (fresh (x ...) (== (list x ...) initial-var) g0 gs ...)))
        (pause empty-state goal)))))
+
 (define (stream-take n s)
   (if (eqv? 0 n) '()
       (let ((s (mature s)))
         (if (pair? s)
             (cons (car s) (stream-take (and n (- n 1)) (cdr s)))
             '()))))
+
 (define-syntax run
   (syntax-rules ()
     ((_ n body ...) (map reify/initial-var (stream-take n (query body ...))))))
+
 (define-syntax run*
   (syntax-rules () ((_ body ...) (run #f body ...))))

--- a/nas.rkt
+++ b/nas.rkt
@@ -1,0 +1,106 @@
+#lang racket
+(require "tools.rkt")
+(require "math.rkt")
+
+(define build-num
+  (lambda (n)
+    (cond
+      ((odd? n)
+       (cons 1
+         (build-num (quotient (- n 1) 2))))
+      ((and (not (zero? n)) (even? n))
+       (cons 0
+         (build-num (quotient n 2))))
+      ((zero? n) '()))))
+
+(define (one? n)
+  (= n 1))
+
+(define (unbuild-num n)
+  (let loop ((n n) (r 0) (i 0))
+    (cond
+     ((null? n) r)
+     ((one? (car n)) (loop (cdr n) (+ r (expt 2 i)) (add1 i)))
+     (else (loop (cdr n) r (add1 i))))))
+
+(define parse-nums
+  (lambda (layers)
+    (cond
+     ((null? layers) '())
+     ((symbol? (car layers))
+      (cons (car layers) (map unbuild-num (cdr layers))))
+     ((pair? layers)
+      (cons (parse-nums (car layers)) (parse-nums (cdr layers))))
+     (else layers))))
+
+(define linearo
+  (lambda (q in out)
+    (== q `(Linear ,in ,out))))
+
+(define percento
+  (lambda (x)
+    (fresh (y)
+      (pluso x y (build-num 99)))))
+
+(define dropouto
+  (lambda (q in out)
+    (fresh (p)
+      (percento p)
+      (== in out)
+      (== q `(Dropout ,in ,out ,p)))))
+
+(define reluo
+  (lambda (q in out)
+    (conde
+     ((== in out)
+      (== q `(Relu ,in ,out))))))
+
+(define layero
+  (lambda (q in out)
+    (conde
+     ((linearo q in out))
+     ((dropouto q in out))
+     ((reluo q in out)))))
+
+(define-relation (countero q i)
+  (fresh (k)
+    (conde
+     ((== q i))
+     ((pluso i '(1) k)
+      (countero q k)))))
+
+(define-relation (archo arch first-in last-out)
+  (conde
+   ((fresh (layer)
+           (layero layer first-in last-out)
+           (== arch `(,layer))))
+   ((fresh (head tail hidden)
+           (countero hidden (build-num 8))
+           (layero head first-in hidden)
+           (archo tail hidden last-out)
+           (== arch `(,head . ,tail))))))
+
+(define conso
+  (lambda (head tail result)
+    (== result `(,head . ,tail))))
+
+(define-relation (appendo ab c abc)
+  (conde
+    ((== '() ab) (== c abc))
+    ((fresh (a b bc)
+       (== `(,a . ,b) ab)
+       (== `(,a . ,bc) abc)
+       (appendo b c bc)))))
+
+(define-relation (full-archo arch first-in last-out)
+  (fresh (layers)
+         (fresh (tmp)
+                (appendo `((IN ,first-in)) layers tmp)
+                (appendo tmp `((OUT ,last-out)) arch))
+         (archo layers first-in last-out)))
+
+;; (parse-nums
+;;  (run 20 (q)
+;;    (full-archo q (build-num 768) (build-num 10))))
+(run 20 (q)
+     (full-archo q (build-num 10) (build-num 2)))

--- a/nas.rkt
+++ b/nas.rkt
@@ -1,6 +1,8 @@
 #lang racket
 (require "tools.rkt")
+
 (require "math.rkt")
+(require "microk-fo.rkt")
 
 (define build-num
   (lambda (n)
@@ -55,20 +57,6 @@
      ((== in out)
       (== q `(Relu ,in ,out))))))
 
-(define layero
-  (lambda (q in out)
-    (conde
-     ((linearo q in out))
-     ((dropouto q in out))
-     ((reluo q in out)))))
-
-(define-relation (countero q i)
-  (fresh (k)
-    (conde
-     ((== q i))
-     ((pluso i '(1) k)
-      (countero q k)))))
-
 (define-relation (archo arch first-in last-out)
   (conde
    ((fresh (layer)
@@ -92,15 +80,126 @@
        (== `(,a . ,bc) abc)
        (appendo b c bc)))))
 
-(define-relation (full-archo arch first-in last-out)
-  (fresh (layers)
-         (fresh (tmp)
-                (appendo `((IN ,first-in)) layers tmp)
-                (appendo tmp `((OUT ,last-out)) arch))
-         (archo layers first-in last-out)))
+(define-relation (layero layer in out)
+  (conde
+   ((== layer `(Linear ,in ,out)))
+   ((== layer `(Relu ,in ,out))
+    (== in out))
+   ((fresh (percent)
+      (== layer `(Dropout ,in ,out ,percent))
+      (== in out)
+      (countero percent)
+      (<o '(1) percent)
+      (<o percent '(0 0 1 0 0 1 1))))))
+
+(define-relation (tailo lst tail)
+  (fresh (a d rst)
+    (conde
+     ((== lst `(,a . ,d))
+      (disj*
+       (== a 1)
+       (== a 0))
+      (== d `(,tail . ())))
+     ((== lst `(,a . ,rst))
+      (disj*
+       (== a 1)
+       (== a 0))
+      (tailo rst tail)))))
+
+(define-relation (countero q)
+  (conde
+   ((== q `(1)))
+   ((tailo q 1))))
+
+(define-relation (layerso layers in out)
+  (conde
+   ((fresh (layer)
+           (layero layer in out)
+           (== layers `(,layer (OUT ,out)))))
+   ((fresh (layer-1 layer-2 hidden)
+           (countero hidden)
+           (<lo '(1) hidden)
+           (layero layer-1 in hidden)
+           (layerso layer-2 hidden out)
+           (== layers `(,layer-1 . ,layer-2))))))
 
 ;; (parse-nums
 ;;  (run 20 (q)
 ;;    (full-archo q (build-num 768) (build-num 10))))
-(run 20 (q)
-     (full-archo q (build-num 10) (build-num 2)))
+
+;; (explore parallel-step (prune/stream (dnf/stream (query (q) (layerso q '(0 1) '(0 1))))))
+
+;; (stream->choices (prune/stream (dnf/stream (query (q)
+;;                                                   (fresh (x y)
+;;                                                          (conj*
+;;                                                           (disj*
+;;                                                            (== x 1)
+;;                                                            (== x 5))
+;;                                                           (== y 2)
+;;                                                           (== q `(,x . ,y))))))))
+
+;; (drop (run 5000 (q)
+;;       (layerso q (build-num 2) (build-num 2))) 4980)
+
+;; (run 20 (q) (layerso q '(0 1) '(0 1)))
+
+;; (drop
+;;  (run 100 (q)
+;;       (archo q (build-num 2) (build-num 2)))
+;;  80)
+
+(define (parallel-expand g)
+  (let loop ((g g))
+    (match g
+      ((conj g1 g2)     (conj (loop g1) (loop g2)))
+      ((relate thunk _) (thunk))
+      (_                g))))
+
+(define (parallel-start st g)
+  (match g
+    ((disj g1 g2)     (parallel-step (mplus (pause st g1) (pause st g2))))
+    ((conj g1 g2)     (parallel-step (bind (pause st g1) g2)))
+    ((relate thunk _) (pause st (thunk)))
+    ((== t1 t2)       (unify t1 t2 st))))
+
+;; Assumes stream is pruned and dnf.
+(define (parallel-step s)
+  (match s
+    ((mplus s1 s2)
+     (let ((s1 (if (mature? s1) s1 (parallel-step s1))))
+       (cond ((not s1) s2)
+             ((pair? s1) (cons (car s1) (mplus s2 (cdr s1))))
+             (else (mplus s2 s1)))))
+    ((bind s g)
+     (let ((s (if (mature? s) s (parallel-step s))))
+       (cond ((not s) #f)
+             ((pair? s) (parallel-step (mplus (pause (car s) g)
+                                              (bind (cdr s) g))))
+             (else (bind s (parallel-expand g))))))
+    ((pause st g) (parallel-start st g))
+    (_            s)))
+
+
+;; Assuming you can present choices and something can select a choice... how do you proceed?
+;;
+;; You `step`. `(step (list-ref choices index))`
+(define (ow-explore/stream step stream)
+  stream)
+
+;; (define responder-thread
+;;   (thread
+;;    (lambda ()
+;;      (define responder (zmq-socket 'rep))
+;;      (zmq-bind responder "tcp://*:5555")
+;;      (let loop ((choices (stream->choices (prune/stream (dnf/stream (pause empty-state (fresh (x) (conde ((== x 0)) ((== x 1))))))))))
+;;        (define msg (zmq-recv-string responder))
+;;        (printf "Server received: ~s\n" msg)
+;;        (zmq-send responder "World")
+;;        (loop)))))
+
+
+
+(let ((stream (pause empty-state (fresh (x)
+                                   (== `(,x) initial-var)
+                                   (conde ((== x 0)) ((== x 1)))))))
+  (prune/stream (dnf/stream stream)))

--- a/server.rkt
+++ b/server.rkt
@@ -1,0 +1,108 @@
+#lang racket/base
+
+(provide run)
+
+(require (prefix-in dispatch: web-server/dispatch)
+         (prefix-in dispatch-log: web-server/dispatchers/dispatch-log)
+         (prefix-in jsexpr: web-server/http/json)
+         (prefix-in xexpr: web-server/http/xexpr)
+         (prefix-in rqstruct: web-server/http/request-structs)
+         (prefix-in servlet: web-server/servlet-env)
+         (only-in racket/match match)
+         (only-in racket/list takef dropf)
+         (only-in racket/port with-output-to-string)
+         json
+         "nas.rkt"
+         "tools.rkt"
+         "microk-fo.rkt"
+         (rename-in "mk-syntax.rkt" (run mk/run))
+         racket/serialize)
+
+(define (not-found-route request)
+  (xexpr:response/xexpr
+   `(html (body (h2 "Uh-oh! Page not found.")))))
+
+(define (home-route request)
+  (xexpr:response/xexpr
+   `(html (body (h2 "Look ma, no state!!!!!!!!!")))))
+
+(define-relation (appendo a b ab)
+  (conde
+   ((== a '()) (== b ab))
+   ((fresh (a1 a2 res)
+      (== a `(,a1 . ,a2))
+      (appendo a2 b res)
+      (== ab `(,a1 . ,res))))))
+
+(define (serializable-choices choices)
+  (cond
+    ((null? choices) '())
+    ((pair? choices) `(,(serializable-choices (car choices)) . ,(serializable-choices (cdr choices))))
+    (else (match choices
+            ((relate th de) (relate 'procedure (cdr de)))
+            ((pause st gl) (pause st (serializable-choices gl)))
+            ((conj g1 g2) (conj (serializable-choices g1) (serializable-choices g2)))
+            ((disj g1 g2) (disj (serializable-choices g1) (serializable-choices g2)))
+            (choices choices)))))
+
+(define (initialize request)
+  (let ((choices
+         (stream->choices
+          (prune/stream
+           (dnf/stream
+            (pause
+             empty-state
+             (fresh (a b)
+                    (== `(,a ,b) initial-var)
+                    (appendo a b `(1 2 3 4)))))))))
+    (jsexpr:response/jsexpr (hash 'choices (with-output-to-string (lambda ()
+                                                                    (write (serialize (serializable-choices choices)))))))))
+
+(define (step request)
+  (let ((choices
+         (stream->choices
+          (prune/stream
+           (dnf/stream
+            (pause
+             empty-state
+             (fresh (a b)
+                    (== `(,a ,b) initial-var)
+                    (appendo a b `(1 2 3 4)))))))))
+    (jsexpr:response/jsexpr (hash 'choices (with-output-to-string (lambda ()
+                                                                    (write (serialize (serializable-choices choices)))))))))
+
+
+(let ((choices
+       (stream->choices
+        (prune/stream
+         (dnf/stream
+          (pause
+           empty-state
+           (fresh (a b)
+                  (== `(,a ,b) initial-var)
+                  (appendo a b `(1 2 3 4)))))))))
+  (list
+   (serialize (serializable-choices choices))
+   (jsexpr? (hash 'choices (with-output-to-string (lambda ()
+                                                    (write (serialize (serializable-choices choices)))))))))
+
+(define-values (route-dispatch route-url)
+  (dispatch:dispatch-rules
+   [("")                           home-route]
+   [("initialize") #:method "post" initialize]
+   [("step")       #:method "post" step]
+   [else                           not-found-route]))
+
+(define (route-dispatch/log-middleware req)
+  (display (dispatch-log:apache-default-format req))
+  (flush-output)
+  (route-dispatch req))
+
+(define (run)
+  (servlet:serve/servlet
+   route-dispatch/log-middleware
+   #:servlet-path "/"
+   #:servlet-regexp #rx""
+   #:stateless? #t))
+
+(run)

--- a/tools.rkt
+++ b/tools.rkt
@@ -15,13 +15,18 @@
  parallel-step-simple
  parallel-step
 
+ stream->choices
  mature/step
  stream-take/step
  run/step-simplify
  run/step
  run*/step
  step
- 
+
+ query
+ goal->constraints
+ walked-term
+
  drive/policy
  drive/stdio
 
@@ -82,7 +87,9 @@
          (#f          #f)
          (st          (pause st (=/= t1 t2))))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Transform into Disjunctive Normal Form.
 (define (dnf/stream s)
   (define (push-pause st g)
@@ -201,6 +208,7 @@
 
 (define (simplify s)
   (prune/stream (dnf/stream s)))
+
 (define-syntax run/step-simplify
   (syntax-rules ()
     ((_ step n body ...) (map reify/initial-var (stream-take/step


### PR DESCRIPTION
Was playing with this in `examples.rkt`.

```racket
;;;; This works as expected.
;; (explore step (query (a b) (appendo a b '(1 2 3 4))))

;;;; This fails with:
(explore parallel-step (query (a b) (appendo a b '(1 2 3 4))))
;; ————— run examples.rkt —————
;; Using step procedure: parallel-step
;; Exploring query:
;; (query (a b) (appendo a b (quote (1 2 3 4))))

;; ================================================================================
;; Current Depth: 0
;; Number of Choices: 1

;; | Choice 1:
;; |  a = #s(var a 1)
;; |  b = #s(var b 2)
;; |  Constraints:
;; |  * (appendo #s(var a 1) #s(var b 2) (1 2 3 4))

;; [h]elp, [u]ndo, or choice number>
;; 1

;; ================================================================================
;; Previous Choice:
;; |  a = #s(var a 1)
;; |  b = #s(var b 2)
;; |  Constraints:
;; |  * (appendo #s(var a 1) #s(var b 2) (1 2 3 4))

;; Current Depth: 1
;; Number of Choices: 2

;; | Choice 1:
;; match: no matching clause for #s(bind #s(state ((#s(var #f 0) #s(var a 1) #s(var b 2))) () () ()) #s(conj #s(== () #s(var a 1)) #s(== #s(var b 2) (1 2 3 4))))
```

I think I got it.

`prune/goal` returns a pause: https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/tools.rkt#L83

`parallel-step` then [calls](https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/tools.rkt#L191) `parallel-start` which then just [returns the state](https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/tools.rkt#L170).

That doesn't happen with the regular `step` because [regular step](https://github.com/eihli/first-order-miniKanren/blob/parallel-step-not-terminating/microk-fo.rkt#L54) returns `(state->stream ...)`.

Wrapping the `==` match in `parallel-step-start` with a `state->stream` call seems to be the solution.